### PR TITLE
Fixed the dupe bug with Jukeboxes in RegenTempBlock.

### DIFF
--- a/src/com/jedk1/jedcore/util/RegenTempBlock.java
+++ b/src/com/jedk1/jedcore/util/RegenTempBlock.java
@@ -47,7 +47,7 @@ public class RegenTempBlock {
 		if (DensityShift.isPassiveSand(block)) {
 			DensityShift.revertSand(block);
 		}
-		if (block.getState() instanceof InventoryHolder) {
+		if (block.getState() instanceof InventoryHolder || block.getType() == Material.JUKEBOX) {
 			return;
 		}
 		if (blocks.containsKey(block)) {


### PR DESCRIPTION
Checked the Spigot javadocs and Jukeboxes don't inherit InventoryHolder or Container despite holding an item, just testing the Material directly instead.