### PR TITLE
Bandaid fixes for 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.16.1-R0.1-SNAPSHOT</version>
+      <version>1.18-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!-- ProjectKorra -->

--- a/src/com/jedk1/jedcore/JCMethods.java
+++ b/src/com/jedk1/jedcore/JCMethods.java
@@ -32,7 +32,10 @@ public class JCMethods {
 			Material.WHITE_TULIP, Material.ROSE_BUSH, Material.BLUE_ORCHID, Material.LILAC, Material.OXEYE_DAISY,
 			Material.AZURE_BLUET, Material.PEONY, Material.SUNFLOWER, Material.LARGE_FERN, Material.RED_MUSHROOM,
 			Material.BROWN_MUSHROOM, Material.PUMPKIN_STEM, Material.MELON_STEM, Material.WHEAT, Material.TALL_GRASS,
-			Material.BEETROOTS, Material.CARROTS, Material.POTATOES
+			Material.BEETROOTS, Material.CARROTS, Material.POTATOES, Material.AZALEA, Material.FLOWERING_AZALEA,
+			Material.FLOWERING_AZALEA_LEAVES, Material.AZALEA_LEAVES, Material.CRIMSON_FUNGUS, Material.WARPED_FUNGUS, 
+			Material.BIG_DRIPLEAF, Material.BIG_DRIPLEAF_STEM, Material.SMALL_DRIPLEAF, Material.HANGING_ROOTS,
+			Material.BAMBOO, Material.BAMBOO_SAPLING, Material.GLOW_LICHEN, Material.CAVE_VINES, Material.CAVE_VINES_PLANT
 	};
 	private static List<String> worlds = new ArrayList<String>();
 	private static List<String> combos = new ArrayList<String>();

--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESStream.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESStream.java
@@ -167,9 +167,9 @@ public class ESStream extends AvatarAbility implements AddonAbility {
 			}
 
 			ParticleEffect.FLAME.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
-			ParticleEffect.LARGE_SMOKE.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
+			ParticleEffect.SMOKE_LARGE.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
 			ParticleEffect.FIREWORKS_SPARK.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
-			ParticleEffect.LARGE_SMOKE.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
+			ParticleEffect.SMOKE_LARGE.display(stream, 20, Math.random(), Math.random(), Math.random(), 0.5);
 			ParticleEffect.EXPLOSION_HUGE.display(stream, 5, Math.random(), Math.random(), Math.random(), 0.5);
 
 			stream.getWorld().playSound(stream, (rand.nextBoolean()) ? Sound.ENTITY_FIREWORK_ROCKET_BLAST : Sound.ENTITY_FIREWORK_ROCKET_BLAST_FAR, 1f, 1f);
@@ -211,9 +211,9 @@ public class ESStream extends AvatarAbility implements AddonAbility {
 						break;
 					case 1:
 						if (rand.nextInt(30) == 0) {
-							ParticleEffect.MOB_SPELL.display(pl, 0, 255, 255, 255, 0.003);
+							ParticleEffect.SPELL_MOB.display(pl, 0, 255, 255, 255, 0.003);
 						} else {
-							ParticleEffect.MOB_SPELL_AMBIENT.display(pl, 1, 0.05, 0.05, 0.05, 0.005);
+							ParticleEffect.SPELL_MOB_AMBIENT.display(pl, 1, 0.05, 0.05, 0.05, 0.005);
 						}
 						break;
 					case 2:

--- a/src/com/jedk1/jedcore/ability/waterbending/Drain.java
+++ b/src/com/jedk1/jedcore/ability/waterbending/Drain.java
@@ -35,17 +35,17 @@ public class Drain extends WaterAbility implements AddonAbility {
 	private List<Location> locations = new ArrayList<>();
 	private static final Biome[] INVALID_BIOMES = {
 			Biome.DESERT,
-			Biome.DESERT_HILLS,
 			Biome.BASALT_DELTAS,
 			Biome.CRIMSON_FOREST,
 			Biome.NETHER_WASTES,
 			Biome.SOUL_SAND_VALLEY,
 			Biome.WARPED_FOREST,
 			Biome.BADLANDS,
-			Biome.BADLANDS_PLATEAU,
+			Biome.WOODED_BADLANDS,
 			Biome.ERODED_BADLANDS,
 			Biome.SAVANNA,
-			Biome.SAVANNA_PLATEAU
+			Biome.SAVANNA_PLATEAU,
+			Biome.WINDSWEPT_SAVANNA
 	};
 
 	private long regenDelay;

--- a/src/com/jedk1/jedcore/ability/waterbending/FrostBreath.java
+++ b/src/com/jedk1/jedcore/ability/waterbending/FrostBreath.java
@@ -35,22 +35,22 @@ public class FrostBreath extends IceAbility implements AddonAbility {
 			Material.LAVA,
 			Material.AIR,
 			Material.VOID_AIR,
-			Material.CAVE_AIR
+			Material.CAVE_AIR,
+			Material.LIGHT
 	);
 	private static final List<Biome> INVALID_BIOMES = Arrays.asList(
-			Biome.DESERT,
-			Biome.DESERT_HILLS,
-			Biome.BASALT_DELTAS,
-			Biome.CRIMSON_FOREST,
-			Biome.NETHER_WASTES,
-			Biome.SOUL_SAND_VALLEY,
-			Biome.WARPED_FOREST,
-			Biome.BADLANDS,
-			Biome.BADLANDS_PLATEAU,
-			Biome.ERODED_BADLANDS,
-			Biome.WOODED_BADLANDS_PLATEAU,
-			Biome.SAVANNA,
-			Biome.SAVANNA_PLATEAU
+		Biome.DESERT,
+		Biome.BASALT_DELTAS,
+		Biome.CRIMSON_FOREST,
+		Biome.NETHER_WASTES,
+		Biome.SOUL_SAND_VALLEY,
+		Biome.WARPED_FOREST,
+		Biome.BADLANDS,
+		Biome.WOODED_BADLANDS,
+		Biome.ERODED_BADLANDS,
+		Biome.SAVANNA,
+		Biome.SAVANNA_PLATEAU,
+		Biome.WINDSWEPT_SAVANNA
 	);
 
 	public Config config;
@@ -274,8 +274,8 @@ public class FrostBreath extends IceAbility implements AddonAbility {
 				}
 
 				ParticleEffect.SNOW_SHOVEL.display(loc, config.particles, Math.random(), Math.random(), Math.random(), size);
-				ParticleEffect.SPELL_MOB.display(getOffsetLocation(loc, offset), 0, 220, 220, 220, 0.003, new Particle.DustOptions(Color.fromRGB(220, 220, 220), 1));
-				ParticleEffect.SPELL_MOB.display(getOffsetLocation(loc, offset), 0, 150, 150, 255, 0.0035, new Particle.DustOptions(Color.fromRGB(150, 150, 255), 1));
+				ParticleEffect.SPELL_MOB.display(getOffsetLocation(loc, offset), 0, 220, 220, 220, 0.003/*, new Particle.DustOptions(Color.fromRGB(220, 220, 220), 1)*/);
+				ParticleEffect.SPELL_MOB.display(getOffsetLocation(loc, offset), 0, 150, 150, 255, 0.0035/*, new Particle.DustOptions(Color.fromRGB(150, 150, 255), 1)*/);
 			}
 		}
 

--- a/src/com/jedk1/jedcore/ability/waterbending/HealingWaters.java
+++ b/src/com/jedk1/jedcore/ability/waterbending/HealingWaters.java
@@ -60,15 +60,15 @@ public class HealingWaters extends HealingAbility implements AddonAbility {
 				if(entity instanceof LivingEntity && inWater(entity)){
 					Location playerLoc = entity.getLocation();
 					playerLoc.add(0, 1, 0);
-					ParticleEffect.MOB_SPELL_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
-					ParticleEffect.WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
+					ParticleEffect.SPELL_MOB_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
+					ParticleEffect.WATER_WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
 					giveHPToEntity((LivingEntity) entity);
 				}
 			}else{
 				Location playerLoc = player.getLocation();
 				playerLoc.add(0, 1, 0);
-				ParticleEffect.MOB_SPELL_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
-				ParticleEffect.WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
+				ParticleEffect.SPELL_MOB_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
+				ParticleEffect.WATER_WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
 				giveHP(player);
 			}
 		}else if(hasWaterSupply(player) && player.isSneaking()){
@@ -79,8 +79,8 @@ public class HealingWaters extends HealingAbility implements AddonAbility {
 					if(dLe.getHealth() < dLe.getMaxHealth()){
 						Location playerLoc = entity.getLocation();
 						playerLoc.add(0, 1, 0);
-						ParticleEffect.MOB_SPELL_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
-						ParticleEffect.WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
+						ParticleEffect.SPELL_MOB_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
+						ParticleEffect.WATER_WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
 						giveHPToEntity((LivingEntity) entity);
 						entity.setFireTicks(0);
 						Random rand = new Random();
@@ -91,8 +91,8 @@ public class HealingWaters extends HealingAbility implements AddonAbility {
 			}else{
 				Location playerLoc = player.getLocation();
 				playerLoc.add(0, 1, 0);
-				ParticleEffect.MOB_SPELL_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
-				ParticleEffect.WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
+				ParticleEffect.SPELL_MOB_AMBIENT.display(playerLoc, 3, Math.random(), Math.random(), Math.random(), 0.0);
+				ParticleEffect.WATER_WAKE.display(playerLoc, 25, 0, 0, 0, 0.05F);
 				giveHP(player);
 				player.setFireTicks(0);
 				Random rand = new Random();

--- a/src/com/jedk1/jedcore/util/MaterialUtil.java
+++ b/src/com/jedk1/jedcore/util/MaterialUtil.java
@@ -16,7 +16,7 @@ public class MaterialUtil {
             Material.AZURE_BLUET, Material.RED_TULIP, Material.ORANGE_TULIP, Material.WHITE_TULIP, Material.PINK_TULIP,
             Material.OXEYE_DAISY, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM, Material.TORCH, Material.FIRE,
             Material.WHEAT, Material.SNOW, Material.SUGAR_CANE, Material.VINE, Material.SUNFLOWER, Material.LILAC,
-            Material.LARGE_FERN, Material.ROSE_BUSH, Material.PEONY
+            Material.LARGE_FERN, Material.ROSE_BUSH, Material.PEONY, Material.LIGHT
     );
 
     private static List<Material> signMaterials = new ArrayList<>();


### PR DESCRIPTION
Fixed Stream and Healingwaters for using out of date names for ParticleEffect

Fixed drain to support the new biomes
Fixed Frostbreath to support new biomes, added light to ignored invalid materials, commented out Particle.DustOptions() I think it's broken
Added new plants from 1.17 and 1.18 to JCMethods, added Material.LIGHT to MaterialUtil