### PR TITLE
Fix AirSlam grabbing SwiftStream's instructions

### DIFF
--- a/src/com/jedk1/jedcore/ability/airbending/combo/AirSlam.java
+++ b/src/com/jedk1/jedcore/ability/airbending/combo/AirSlam.java
@@ -128,7 +128,7 @@ public class AirSlam extends AirAbility implements AddonAbility, ComboAbility {
 
 	@Override
 	public String getInstructions() {
-		return JedCoreConfig.getConfig(player).getString("Abilities.Air.AirCombo.SwiftStream.Instructions");
+		return JedCoreConfig.getConfig(player).getString("Abilities.Air.AirCombo.AirSlam.Instructions");
 	}
 
 	@Override


### PR DESCRIPTION
AirSlam was getting SwiftStream's instructions. Caused some confusion.